### PR TITLE
Adding tags for precision runs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
 
 - include: 'rvm.yml'
+  tags:
+    - rvm_io
+    - rvm_io_rvm
 - include: 'rubies.yml'
+  tags:
+    - rvm_io
+    - rvm_io_rubies


### PR DESCRIPTION
Addng tags allows one to (re-)run precisely which part of the Playbook they want/need. It also allows you to use '--tags' on the CLI, thus giving you control over which Playbook/Role to run exclusively.

The use of two tags allows us to either run everything ("rvm_io"), or just one specific task ("rvm_io_rubies").
