### PR TITLE
updating from old version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ rvm1_rubies:
 rvm1_delete_ruby:
 
 # Install path for rvm (defaults to system wide)
-rvm1_install_path: '/usr/local/lib/rvm'
+rvm1_install_path: '/usr/local/rvm'
 
 # Add or remove any install flags
 # NOTE: If you are doing a USER BASED INSTALL then


### PR DESCRIPTION
I was using an older version and upgraded to the latest. It seems like the new version installs rvm in `usr/local/lib/rvm` rather than `usr/local/rvm` where it used to be installed.

What's the best way to switch rvm's and get rid of the old version?
