### PR TITLE
Allow --user-install symlinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ rvm1_gpg_keys: 'D39DC0E3'
 
 # The GPG key server
 rvm1_gpg_key_server: 'hkp://keys.gnupg.net'
+
+rvm1_symlink_to: '/usr/local/bin'
+rvm1_symlink_user: 'root'
+rvm1_symlink_group: 'root'
 ```
 
 ## Example playbook
@@ -78,12 +82,17 @@ run the play with sudo because it will need to write to `/usr/local/lib/rvm`.
 
 #### To the same user as `ansible_ssh_user`
 
-You do not need to include `sudo: True` in this case, just overwrite `rvm_install_path` and set the `--user-install` flag:
+You do not need to include `sudo: True` in this case, just overwrite `rvm_install_path`; set the `--user-install` flag; configure the symlink location; and define ownerships of the symlinks:
 
 ```
 rvm1_install_flags: '--auto-dotfiles --user-install'
 rvm1_install_path: '/home/{{ ansible_ssh_user }}/.rvm'
+rvm1_symlink_to: '/usr/{{ansible_ssh_user}}/.rvm/bin'
+rvm1_symlink_user: '{{ansible_ssh_user}}'
+rvm1_symlink_group: '{{ansible_ssh_user}}'
 ```
+
+Failing to set the symlink user/group combination will cause the Playbook to fail (due to the default value being 'root')
 
 #### To a user that is not `ansible_ssh_user`
 
@@ -94,6 +103,9 @@ supply a different user account:
 ```
 rvm1_install_flags: '--auto-dotfiles --user-install'
 rvm1_install_path: '/home/someuser/.rvm'
+rvm1_symlink_to: '/home/someuser/.rvm/bin'
+rvm1_symlink_user: 'someuser'
+rvm1_symlink_group: 'someuser'
 ```
 
 ## Upgrading and removing old versions of ruby

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,7 @@ rvm1_gpg_keys: 'D39DC0E3'
 
 # The GPG key server
 rvm1_gpg_key_server: 'hkp://keys.gnupg.net'
+
+rvm1_symlink_to: '/usr/local/bin'
+rvm1_symlink_user: 'root'
+rvm1_symlink_group: 'root'

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -28,9 +28,8 @@
     state: 'link'
     src: '{{ rvm1_install_path }}/wrappers/default/{{ item }}'
     dest: '{{ rvm1_symlink_to }}/{{ item }}'
-    owner: 'root'
-    group: 'root'
-  when: not '--user-install' in rvm1_install_flags
+    owner: '{{ rvm1_symlink_user }}'
+    group: '{{ rvm1_symlink_group }}'
   with_items: rvm1_symlink_binaries
 
 - name: Detect if ruby version can be deleted

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,6 +19,3 @@ rvm1_symlink_binaries:
   - 'ruby'
   - 'testrb'
 
-rvm1_symlink_to: '/usr/local/bin'
-rvm1_symlink_user: 'root'
-rvm1_symlink_group: 'root'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,3 +20,5 @@ rvm1_symlink_binaries:
   - 'testrb'
 
 rvm1_symlink_to: '/usr/local/bin'
+rvm1_symlink_user: 'root'
+rvm1_symlink_group: 'root'


### PR DESCRIPTION
When using a user install, the symbolic links will usually be skipped. This means Bundler, as well as the other gems being installed by this role, aren't accessible from a shell script uploaded and executed by Ansible. Here is a very simple, example shell script, followed by the Playbook uploading it, and the Playbook wrapping all of these efforts:

_Bundle install our project requirements_:

``` bash
#!/bin/bash
bundle install
```

_The Playbook uploading and executing the above_:

``` yaml

---
- name: Upload our Gemfile
  copy: src=Gemfile dest=/home/vagrant/
- name: Run our script 
  script: bundle_install.sh
```

_The "site.yml" Playbook implementing the above_:

``` yaml

---
- hosts: all
  sudo: no
  vars:
    rvm1_install_path: '/home/vagrant/.rvm'
    rvm1_install_flags: '--auto-dotfiles --user-install'
    rvm1_rvm_check_for_updates: False
    rvm1_symlink_to: '/home/vagrant/.rvm/bin'
    rvm1_symlink_user: 'vagrant'
    rvm1_symlink_group: 'vagrant'
  roles:
    - rvm_io.rvm1-ruby
    - rubyproject
```

("rubyproject" just being a dummy project with a Gemfile)

When attempting to execute the Bash script, it was unable to find Bundler. This is because the symbolic link in '/usr/local/bin/' does not exist at this point. With the changes I have implemented in this PR, the symbolic links are created in the user's home directory, under '.rvm/bin', making the core gems (Bundler, etc) available from the shell and from shell scripts. The shell script can now execute, finds Bundler, and successfully installs my gems.
