### PR TITLE
Add option to overwrite the ownership of the RVM installation directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ rvm1_install_flags: '--auto-dotfiles --user-install'
 rvm1_install_path: '/home/someuser/.rvm'
 ```
 
+### Setting the ownership of the installation directory
+
+The installation directory defined in `rvm_install_path` will have as the owner the same user
+that is running the commands, in this case the `ansible_ssh_user`. If you want to grant ownership to a different user, overwite the `rvm1_install_owner`:
+
+```
+rvm1_install_owner: 'someuser'
+```
+
 ## Upgrading and removing old versions of ruby
 
 A common work flow for upgrading your ruby version would be:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ rvm1_delete_ruby:
 # Install path for rvm (defaults to system wide)
 rvm1_install_path: '/usr/local/rvm'
 
+# User of the installation directory that will be granted with ownership permissions
+rvm1_install_owner: ''
+
 # Add or remove any install flags
 # NOTE: If you are doing a USER BASED INSTALL then
 #       make sure you ADD the --user-install flag below

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -45,3 +45,7 @@
 - name: Configure rvm
   command: '{{ rvm1_rvm }} autolibs 3'
   when: not rvm_binary.stat.exists
+
+- name: Set ownership of the installation directory
+  command:  'chown -R {{ rvm1_install_owner }} {{ rvm1_install_path }}'
+  when: rvm1_install_owner != ''


### PR DESCRIPTION
Add an optional task to be able to set which user should be the owner of the rvm installation directory, avoiding follow up issues regarding write permissions to the directory.

Reference issue #23 
