### PR TITLE
Allow users to configure the autolibs mode of installed rvms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ rvm1_gpg_keys: 'D39DC0E3'
 
 # The GPG key server
 rvm1_gpg_key_server: 'hkp://keys.gnupg.net'
+
+# autolib mode, see https://rvm.io/rvm/autolibs
+rvm1_autolib_mode: 3
 ```
 
 ## Example playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,6 @@ rvm1_gpg_keys: 'D39DC0E3'
 
 # The GPG key server
 rvm1_gpg_key_server: 'hkp://keys.gnupg.net'
+
+# autolib mode, see https://rvm.io/rvm/autolibs
+rvm1_autolib_mode: 3

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -43,5 +43,5 @@
   when: rvm_binary.stat.exists and rvm1_rvm_check_for_updates
 
 - name: Configure rvm
-  command: '{{ rvm1_rvm }} autolibs 3'
+  command: '{{ rvm1_rvm }} autolibs {{ rvm1_autolib_mode }}'
   when: not rvm_binary.stat.exists


### PR DESCRIPTION
On Ubuntu 14.04 without sudo, the default autolibs mode 3 causes the
role to hang when trying to install ruby-1.9.3-p0.