### PR TITLE
fixes the rvm install when rvm1_user is specified

### DIFF
--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -30,18 +30,22 @@
   command: 'gpg --keyserver {{ rvm1_gpg_key_server }} --recv-keys {{ rvm1_gpg_keys }}'
   changed_when: False
   when: rvm1_gpg_keys != ''
+  sudo_user: '{{ rvm1_user }}'
 
 - name: Install rvm
   command: >
     {{ rvm1_temp_download_path }}/rvm-installer.sh {{ rvm1_rvm_version }}
     --path {{ rvm1_install_path }} {{ rvm1_install_flags }}
   when: not rvm_binary.stat.exists
+  sudo_user: '{{ rvm1_user }}'
 
 - name: Update rvm
   shell: '{{ rvm1_rvm }} get {{ rvm1_rvm_version }} && {{ rvm1_rvm }} reload'
   changed_when: False
   when: rvm_binary.stat.exists and rvm1_rvm_check_for_updates
+  sudo_user: '{{ rvm1_user }}'
 
 - name: Configure rvm
   command: '{{ rvm1_rvm }} autolibs {{ rvm1_autolib_mode }}'
   when: not rvm_binary.stat.exists
+  sudo_user: '{{ rvm1_user }}'


### PR DESCRIPTION
I was having some issues when choosing a regular user for rvm1_user where the `.rvm` directory in `/home/{{rvm1_user}}/` would be owned by `root`. The issue would cause an error when the role would try to install rubies. The changes in this PR were the things that I needed to change for it to work but I am not sure if they break other use cases. This is also my second week doing any ansible so let me know if I did anything silly.

 - use rvm1_user for the gpg keys
 - use rvm1_user when installing rvm
 - use rvm1_user when updating rvm
 - use rvm1_user when configuring rvm