### PR TITLE
Add option for passing ruby install flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ rvm1_install_path: '/usr/local/rvm'
 #       make sure you ADD the --user-install flag below
 rvm1_install_flags: '--auto-dotfiles'
 
+# Add additional ruby install flags
+rvm1_ruby_install_flags:
+
 # Set the owner for the rvm directory
 rvm1_user: 'root'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ rvm1_install_path: '/usr/local/rvm'
 #       make sure you ADD the --user-install flag below
 rvm1_install_flags: '--auto-dotfiles'
 
+# Add additional ruby install flags
+rvm1_ruby_install_flags:
+
 # Set the owner for the rvm directory
 rvm1_user: 'root'
 

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -9,7 +9,7 @@
   when: rvm1_rubies
 
 - name: Install rubies
-  command: '{{ rvm1_rvm }} install {{ item.item }}'
+  command: '{{ rvm1_rvm }} install {{ item.item }} {{ rvm1_ruby_install_flags }}'
   when: rvm1_rubies and item.rc != 0
   with_items: detect_rubies.results
   sudo_user: '{{ rvm1_user }}'


### PR DESCRIPTION
This commit adds a var called `rvm_1_ruby_install_flags`, so you can pass `./configure` flags such as `--with-jemalloc` to `rvm install`.