### PR TITLE
Using rvm1_user when creating alias for default ruby

### DIFF
--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -23,6 +23,7 @@
   command: '{{ rvm1_rvm }} alias create default {{ rvm1_default_ruby_version }}'
   when: detect_default_ruby_version.stdout == '' or
         rvm1_default_ruby_version not in detect_default_ruby_version.stdout
+  sudo_user: '{{ rvm1_user }}'
 
 - name: Symlink ruby related binaries on the system path
   file:


### PR DESCRIPTION
When i was trying to use the role setting a rvm1_user different from the ansible_ssh_user, the task failed due to lack of permissions in the .rvm directory.
