### PR TITLE
Variable for specifying bundler version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,6 @@ rvm1_gpg_key_server: 'hkp://keys.gnupg.net'
 
 # autolib mode, see https://rvm.io/rvm/autolibs
 rvm1_autolib_mode: 3
+
+# The version of bundler to install
+rvm1_bundler_version: 1.9.9

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -27,7 +27,7 @@
 - name: Install bundler if not installed
   shell: >
     {{ rvm1_install_path }}/wrappers/{{ item }}/gem list
-    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item }}/gem install bundler ; fi
+    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item }}/gem install -v {{ rvm1_bundler_version }} bundler ; fi
   args:
     creates: '{{ rvm1_install_path }}/wrappers/{{ item }}/bundler'
   with_items: rvm1_rubies


### PR DESCRIPTION
It is pretty important to be able to specify the version of bundler
because a simple `gem install` command does not follow semantic
versioning -- a version incompatible with your codebase might be
installed.
