### PR TITLE
VICT-73 Added force option to ensure local files are unlinked to allow symlink creation

### DIFF
--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -41,6 +41,7 @@
     dest: '{{ rvm1_symlink_to }}/{{ item }}'
     owner: 'root'
     group: 'root'
+    force: yes
   when: not '--user-install' in rvm1_install_flags
   with_items: rvm1_symlink_binaries
 


### PR DESCRIPTION
Added "force: yes" to rubies.yml to ensure local files are unlinked before attempting to create the symlinks.