### PR TITLE
Improve Bundler setup to support RVM aliases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ script:
     && (echo 'Multiple rubies test: pass' && exit 0)
     || (echo 'Multiple rubies test: fail' && exit 1)
   - >
+    ~/.rvm/wrappers/ruby-2.1.2/bundle -v
+    | grep -q 'Bundler version'
+    && (echo 'Bundler setup test: pass' && exit 0)
+    || (echo 'Bundler setup test: fail' && exit 1)
+  - >
     ansible-playbook $SITE_AND_INVENTORY --connection=local --extra-vars='rvm1_delete_ruby=ruby-2.1.0'
     | grep -q 'ok=1.*failed=0'
     && (echo 'Delete ruby test: pass' && exit 0)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 language: 'python'
 python: '2.7'
 
+sudo: required
+
 env:
   - SITE_AND_INVENTORY='tests/test.yml -i tests/inventory'
 

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -25,9 +25,7 @@
         rvm1_default_ruby_version not in detect_default_ruby_version.stdout
 
 - name: Install bundler if not installed
-  shell: >
-    {{ rvm1_install_path }}/wrappers/{{ item }}/gem list
-    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item }}/gem install bundler ; fi
+  shell: bash -lc 'cd; rvm use {{ item }}; gem list | if ! grep "^bundler " ; then gem install bundler ; fi'
   args:
     creates: '{{ rvm1_install_path }}/wrappers/{{ item }}/bundler'
   with_items: rvm1_rubies

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,7 +7,7 @@
   vars:
     rvm1_rubies:
       - 'ruby-2.1.0'
-      - 'ruby-2.1.2'
+      - '2.1.2'
     rvm1_install_path: '/home/travis/.rvm'
     rvm1_install_flags: '--auto-dotfiles --user-install'
 


### PR DESCRIPTION
Without this change, the Bundler setup fails when the `rvm_rubies` list contains valid RVM aliases, like
following examples:
- ruby-1.9.3
- ruby-2.0
- 2.1
- ruby
- jruby

These aliases are quite useful to refer to the latest release of a specific Ruby branch.
