### PR TITLE
support update configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ rvm1_gpg_key_server: 'hkp://keys.gnupg.net'
 
 # autolib mode, see https://rvm.io/rvm/autolibs
 rvm1_autolib_mode: 3
+
+# Update $rvm_path/config/db, see https://rvm.io/rvm/configuration
+# e.g
+# rvm1_configurations:
+#   ruby_url: http://ruby.taobao.org/mirrors/ruby
+# 
+rvm1_configurations: {}
 ```
 
 ## Example playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,10 @@ rvm1_gpg_key_server: 'hkp://keys.gnupg.net'
 
 # autolib mode, see https://rvm.io/rvm/autolibs
 rvm1_autolib_mode: 3
+
+# Update $rvm_path/config/db, see https://rvm.io/rvm/configuration
+# e.g
+# rvm1_configurations:
+#   ruby_url: http://ruby.taobao.org/mirrors/ruby
+# 
+rvm1_configurations: {}

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -49,3 +49,13 @@
   command: '{{ rvm1_rvm }} autolibs {{ rvm1_autolib_mode }}'
   when: not rvm_binary.stat.exists
   sudo_user: '{{ rvm1_user }}'
+
+- name: Update rvm configuration db
+  lineinfile: "dest={{ rvm1_install_path }}/config/db state=present regexp='^{{ item }}=' line='{{ item }}={{ rvm1_configurations[item] }}'"
+  with_items: rvm1_configurations.keys()
+
+- name: Reload rvm when configuration db updated
+  shell: '{{ rvm1_rvm }} reload'
+  changed_when: False
+  when: rvm1_configurations.keys()
+  sudo_user: '{{ rvm1_user }}'


### PR DESCRIPTION
When we use rvm install ruby, the default ruby binary file download host is http://cache.ruby-lang.org.
In China, usually we cannot access it, so we should change rvm "ruby_url" configuration in $rvm_path/config/db .

In this pull request, I add a default variable ```rvm1_configurations: {}```, and add two tasks(update config/db and reload rvm), they will run after rvm installed.

the usage like this
```
rvm1_configurations:
   ruby_url: http://ruby.taobao.org/mirrors/ruby
```

I wish that you merge it, thanks.