### PR TITLE
Add a test to show failure to create a gemset

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,3 +13,7 @@
 
   roles:
     - rvm1-ansible
+
+  post_tasks:
+    - name: Test | Can create a gemset
+      command: 'rvm gemset create test'


### PR DESCRIPTION
RVM does not install correctly and is unable to run basic commands.  This example is attempting to create a gemset after rvm is installed.