### PR TITLE
This fixes the location of the bundler pointing to the global ruby version

### DIFF
--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -26,10 +26,10 @@
 
 - name: Install bundler if not installed
   shell: >
-    {{ rvm1_install_path }}/wrappers/{{ item }}/gem list
-    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item }}/gem install bundler ; fi
+    {{ rvm1_install_path }}/wrappers/{{ item }}@global/gem list
+    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item }}@global/gem install bundler ; fi
   args:
-    creates: '{{ rvm1_install_path }}/wrappers/{{ item }}/bundler'
+    creates: '{{ rvm1_install_path }}/wrappers/{{ item }}@global/bundler'
   with_items: rvm1_rubies
   register: bundler_install
   changed_when: '"Successfully installed bundler" in bundler_install.stdout'


### PR DESCRIPTION
We found an issue with the gem and bundler directory location just as mentioned in this issue #71 , 'update #46' 
Before the fix bundler gem was installed in default gemset - this is only available when you run "rvm use ruby-2..2.2" but we need it in any gemset: "rvm use ruby@gemset" and this is achieved by installing bundler gem in the "@global" gemset that is inherited by all the gemsets on given ruby.
