### PR TITLE
update rvm installer path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ rvm1_ruby_install_flags:
 rvm1_user: 'root'
 
 # URL for the latest installer script
-rvm1_rvm_latest_installer: 'https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer'
+rvm1_rvm_latest_installer: 'https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer'
 
 # rvm version to use
 rvm1_rvm_version: 'stable'


### PR DESCRIPTION
The rvm repository on GitHub has moved. Update the installer path to
this new location.