### PR TITLE
[OI] Ensure installed rubies and gems are owned correctly by rvm1_user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - '__rvm_unload ; rm -rf ~/.rvm'
 
 install:
-  - 'pip install ansible==1.7.1'
+  - 'pip install ansible==2.0.0'
   - 'printf "[defaults]\nroles_path = ../" > ansible.cfg'
 
 script:

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -25,7 +25,8 @@
   command: '{{ rvm1_rvm }} alias create default {{ rvm1_default_ruby_version }}'
   when: detect_default_ruby_version.stdout|default() == '' or
         rvm1_default_ruby_version not in detect_default_ruby_version.stdout
-  sudo_user: '{{ rvm1_user }}'
+  become: yes
+  become_user: '{{ rvm1_user }}'
 
 - name: Detect installed ruby patch number
   shell: >
@@ -34,7 +35,8 @@
   changed_when: False
   register: ruby_patch
   always_run: yes # Run even when in --check mode (http://docs.ansible.com/ansible/playbooks_checkmode.html)
-  sudo_user: '{{ rvm1_user }}'
+  become: yes
+  become_user: '{{ rvm1_user }}'
 
 - name: Install bundler if not installed
   shell: >
@@ -45,7 +47,8 @@
   with_items: ruby_patch.results
   register: bundler_install
   changed_when: '"Successfully installed bundler" in bundler_install.stdout'
-  sudo_user: '{{ rvm1_user }}'
+  become: yes
+  become_user: '{{ rvm1_user }}'
   
 - name: Symlink ruby related binaries on the system path
   file:

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -5,13 +5,13 @@
   changed_when: False
   failed_when: False
   register: detect_rubies
-  with_items: rvm1_rubies
+  with_items: '{{ rvm1_rubies }}'
   when: rvm1_rubies
 
 - name: Install rubies
   command: '{{ rvm1_rvm }} install {{ item.item }} {{ rvm1_ruby_install_flags }}'
   when: rvm1_rubies and item.rc|default(0) != 0
-  with_items: detect_rubies.results
+  with_items: '{{ detect_rubies.results }}'
   become: yes
   become_user: '{{ rvm1_user }}'
 
@@ -32,7 +32,7 @@
 - name: Detect installed ruby patch number
   shell: >
     {{ rvm1_rvm }} list strings | grep {{ item }} | tail -n 1
-  with_items: rvm1_rubies
+  with_items: '{{ rvm1_rubies }}'
   changed_when: False
   register: ruby_patch
   always_run: yes # Run even when in --check mode (http://docs.ansible.com/ansible/playbooks_checkmode.html)
@@ -45,7 +45,7 @@
     | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item.stdout }}/gem install bundler ; fi
   args:
     creates: '{{ rvm1_install_path }}/wrappers/{{ item.stdout }}/bundler'
-  with_items: ruby_patch.results
+  with_items: '{{ ruby_patch.results }}'
   register: bundler_install
   changed_when: '"Successfully installed bundler" in bundler_install.stdout'
   become: yes
@@ -59,7 +59,7 @@
     owner: 'root'
     group: 'root'
   when: not '--user-install' in rvm1_install_flags
-  with_items: rvm1_symlink_binaries
+  with_items: '{{ rvm1_symlink_binaries }}'
   
 - name: Detect if ruby version can be deleted
   command: '{{ rvm1_rvm }} {{ rvm1_delete_ruby }} do true'

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -19,7 +19,8 @@
   command: '{{ rvm1_rvm }} alias list default'
   changed_when: False
   register: detect_default_ruby_version
-  sudo_user: '{{ rvm1_user }}'
+  become: yes
+  become_user: '{{ rvm1_user }}'
 
 - name: Select default ruby
   command: '{{ rvm1_rvm }} alias create default {{ rvm1_default_ruby_version }}'

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -18,11 +18,13 @@
   command: '{{ rvm1_rvm }} alias list default'
   changed_when: False
   register: detect_default_ruby_version
+  sudo_user: '{{ rvm1_user }}'
 
 - name: Select default ruby
   command: '{{ rvm1_rvm }} alias create default {{ rvm1_default_ruby_version }}'
   when: detect_default_ruby_version.stdout|default() == '' or
         rvm1_default_ruby_version not in detect_default_ruby_version.stdout
+  sudo_user: '{{ rvm1_user }}'
 
 - name: Detect installed ruby patch number
   shell: >
@@ -31,6 +33,7 @@
   changed_when: False
   register: ruby_patch
   always_run: yes # Run even when in --check mode (http://docs.ansible.com/ansible/playbooks_checkmode.html)
+  sudo_user: '{{ rvm1_user }}'
 
 - name: Install bundler if not installed
   shell: >
@@ -41,6 +44,7 @@
   with_items: ruby_patch.results
   register: bundler_install
   changed_when: '"Successfully installed bundler" in bundler_install.stdout'
+  sudo_user: '{{ rvm1_user }}'
   
 - name: Symlink ruby related binaries on the system path
   file:

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -67,8 +67,12 @@
   failed_when: False
   register: detect_delete_ruby
   when: rvm1_delete_ruby
+  become: yes
+  become_user: '{{ rvm1_user }}'
 
 - name: Delete ruby version
   command: '{{ rvm1_rvm }} remove {{ rvm1_delete_ruby }}'
   changed_when: False
   when: rvm1_delete_ruby and detect_delete_ruby.rc == 0
+  become: yes
+  become_user: '{{ rvm1_user }}'


### PR DESCRIPTION
Fix for #84 


## FIX

- Add `sudo_user` directive to tasks that install rubies and gems

```

root@ip-10-152-153-205:/opt/ansible# sudo su - jenkins
jenkins@ip-10-152-153-205:~$ ls -ld .rvm
drwxr-xr-x 25 jenkins jenkins 4096 Feb  9 10:38 .rvm
jenkins@ip-10-152-153-205:~$ ls -l .rvm
total 120
drwxr-xr-x  2 jenkins jenkins 4096 Feb  9 10:39 archives
drwxr-xr-x  2 jenkins jenkins 4096 Feb  9 10:38 bin
drwxr-xr-x  3 jenkins jenkins 4096 Feb  9 10:39 config
drwxr-xr-x  3 jenkins jenkins 4096 Feb  9 10:38 contrib
drwxr-xr-x  2 jenkins jenkins 4096 Feb  9 10:38 docs
drwxr-xr-x  2 jenkins jenkins 4096 Feb  9 10:39 environments
drwxr-xr-x  2 jenkins jenkins 4096 Feb  9 10:38 examples
drwxr-xr-x  2 jenkins jenkins 4096 Feb  9 10:38 gem-cache
drwxr-xr-x  4 jenkins jenkins 4096 Feb  9 10:39 gems
drwxr-xr-x  4 jenkins jenkins 4096 Feb  9 10:38 gemsets
drwxr-xr-x  4 jenkins jenkins 4096 Feb  9 10:38 help
drwxr-xr-x  2 jenkins jenkins 4096 Feb  9 10:38 hooks
-rw-r--r--  1 jenkins jenkins   11 Feb  9 10:38 installed.at
drwxr-xr-x  3 jenkins jenkins 4096 Feb  9 10:38 lib
-rw-r--r--  1 jenkins jenkins  603 Feb  9 10:38 LICENSE
drwxr-xr-x  5 jenkins jenkins 4096 Feb  9 10:39 log
drwxr-xr-x  3 jenkins jenkins 4096 Feb  9 10:38 man
drwxr-xr-x 10 jenkins jenkins 4096 Feb  9 10:38 patches
drwxr-xr-x  5 jenkins jenkins 4096 Feb  9 10:38 patchsets
-rw-r--r--  1 jenkins jenkins 9706 Feb  9 10:38 README
-rw-r--r--  1 jenkins jenkins    7 Feb  9 10:38 RELEASE
drwxr-xr-x  3 jenkins jenkins 4096 Feb  9 10:39 rubies
drwxr-xr-x  5 jenkins jenkins 4096 Feb  9 10:38 scripts
drwxr-xr-x  3 jenkins jenkins 4096 Feb  9 10:38 src
drwxr-xr-x  2 jenkins jenkins 4096 Feb  9 10:39 tmp
drwxr-xr-x  2 jenkins jenkins 4096 Feb  9 10:39 user
-rw-r--r--  1 jenkins jenkins    8 Feb  9 10:38 VERSION
drwxr-xr-x  2 jenkins jenkins 4096 Feb  9 10:39 wrappers
jenkins@ip-10-152-153-205:~$ find .rvm/ -user root -exec ls -l {} \;
jenkins@ip-10-152-153-205:~$
```

[files-not-rvm_user-owned-after-fix.txt](https://github.com/rvm/rvm1-ansible/files/122989/files-not-rvm_user-owned-after-fix.txt)
