### PR TITLE
Fix deprecation warnings when using with ansible 2.0

### DIFF
--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -5,13 +5,13 @@
   changed_when: False
   failed_when: False
   register: detect_rubies
-  with_items: rvm1_rubies
+  with_items: '{{ rvm1_rubies }}'
   when: rvm1_rubies
 
 - name: Install rubies
   command: '{{ rvm1_rvm }} install {{ item.item }} {{ rvm1_ruby_install_flags }}'
   when: rvm1_rubies and item.rc|default(0) != 0
-  with_items: detect_rubies.results
+  with_items: '{{ detect_rubies.results }}'
   become: yes
   become_user: '{{ rvm1_user }}'
 
@@ -28,7 +28,7 @@
 - name: Detect installed ruby patch number
   shell: >
     {{ rvm1_rvm }} list strings | grep {{ item }} | tail -n 1
-  with_items: rvm1_rubies
+  with_items: '{{ rvm1_rubies }}'
   changed_when: False
   register: ruby_patch
   always_run: yes # Run even when in --check mode (http://docs.ansible.com/ansible/playbooks_checkmode.html)
@@ -39,7 +39,7 @@
     | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item.stdout }}/gem install bundler ; fi
   args:
     creates: '{{ rvm1_install_path }}/wrappers/{{ item.stdout }}/bundler'
-  with_items: ruby_patch.results
+  with_items: '{{ ruby_patch.results }}'
   register: bundler_install
   changed_when: '"Successfully installed bundler" in bundler_install.stdout'
   
@@ -51,7 +51,7 @@
     owner: 'root'
     group: 'root'
   when: not '--user-install' in rvm1_install_flags
-  with_items: rvm1_symlink_binaries
+  with_items: '{{ rvm1_symlink_binaries }}'
   
 - name: Detect if ruby version can be deleted
   command: '{{ rvm1_rvm }} {{ rvm1_delete_ruby }} do true'


### PR DESCRIPTION
When using this role with ansible 2.0 following warnings will be displayed:
```
[DEPRECATION WARNING]: Using bare variables is deprecated. ...
```