### PR TITLE
retry gpg key import

### DIFF
--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -32,6 +32,10 @@
   when: rvm1_gpg_keys != ''
   become: yes
   become_user: '{{ rvm1_user }}'
+  register: result
+  until: result.rc == 0
+  retries: 5
+  delay: 5
 
 - name: Install rvm
   command: >


### PR DESCRIPTION
GPG key import sometimes fail due to network partitions or errors on the
remote server. Retry the GPG key import up to 5 times if this happens,
so the playbook doesn't fail from temporary network issues.