### PR TITLE
Add option to disable binary symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ rvm1_gpg_key_server: 'hkp://pool.sks-keyservers.net'
 
 # autolib mode, see https://rvm.io/rvm/autolibs
 rvm1_autolib_mode: 3
+
+# Symlink binaries to system path
+rvm1_symlink: true
 ```
 
 ## Example playbooks

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,3 +58,6 @@ root_user: 'root'
 
 # Name of GID 0 group -- BSD systems typically use wheel instead of root
 root_group: '{{ root_user }}'
+
+# Symlink binaries to system path
+rvm1_symlink: true

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -49,7 +49,7 @@
     dest: '{{ rvm1_symlink_to }}/{{ item }}'
     owner: '{{ root_user }}'
     group: '{{ root_group }}'
-  when: not '--user-install' in rvm1_install_flags
+  when: not '--user-install' in rvm1_install_flags and rvm1_symlink
   with_items: '{{ rvm1_symlink_binaries }}'
 
 - name: Symlink bundler binaries on the system path
@@ -59,7 +59,7 @@
     dest: '{{ rvm1_symlink_to }}/{{ item }}'
     owner: '{{ root_user }}'
     group: '{{ root_group }}'
-  when: not '--user-install' in rvm1_install_flags and rvm1_bundler_install
+  when: not '--user-install' in rvm1_install_flags and rvm1_bundler_install and rvm1_symlink
   with_items: '{{ rvm1_symlink_bundler_binaries }}'
 
 - name: Detect if ruby version can be deleted


### PR DESCRIPTION
Symlinks are already disabled for user installs. For cases where
multiple system-wide Ruby versions are provided by RVM, add an option to
disable symlinking of binaries to the system path.

Default `rvm1_symlink` to `true` to maintain existing behavior parity.
