### PR TITLE
Allow rvm to install the openssl pkg

### DIFF
--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -137,3 +137,51 @@
   when: rvm1_delete_ruby and detect_delete_ruby.rc == 0
   become: yes
   become_user: '{{ rvm1_user }}'
+
+- name: Set user ownership of content under rvm1_install_path
+  shell:
+    find '{{ rvm1_install_path }}'
+      \( -iname ".git" -prune \) -o
+      ! -user '{{ item }}'
+      -exec chown -v '{{ item }}' {} + | head -n 1
+  become: yes
+  with_items: '{{ rvm1_install_path_user }}'
+  when:
+    - rvm1_install_path_user is defined
+    - rvm1_install_path_user != None
+  register: rvm1_chown
+  changed_when: '"changed group" in rvm1_chown.stdout'
+  tags:
+    - rvm
+
+- name: Set group ownership of content under rvm1_install_path
+  shell:
+    find '{{ rvm1_install_path }}'
+      \( -iname ".git" -prune \) -o
+      ! -group '{{ item }}'
+      -exec chgrp -v '{{ item }}' {} + | head -n 1
+  become: yes
+  with_items: '{{ rvm1_install_path_group }}'
+  when:
+    - rvm1_install_path_group is defined
+    - rvm1_install_path_group != None
+  register: rvm1_chgrp
+  changed_when: '"changed group" in rvm1_chgrp.stdout'
+  tags:
+    - rvm
+
+- name: Set group permissions of content under rvm1_install_path
+  shell:
+    find '{{ rvm1_install_path }}'
+      \( -iname ".git" -prune \) -o
+      -type d ! -perm -g+s
+      -exec chmod -v g+rwxs {} + | head -n 1
+  become: yes
+  when:
+    - rvm1_install_path_group is defined
+    - rvm1_install_path_group != None
+  register: rvm1_chmod
+  changed_when: '"changed from" in rvm1_chmod.stdout'
+  tags:
+    - rvm
+

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -12,7 +12,7 @@
 - name: Determine distribution_release
   shell: awk -F/ '{print $1}' /etc/debian_version
   register: distribution_release
-  when: 
+  when:
     ansible_distribution == 'Debian' and
     ansible_distribution_release == 'NA'
   always_run: yes
@@ -37,33 +37,33 @@
 
 # Appears we have to test a file as rvm has no way to list packages it installed
 - name: Determine if rvm pkg openssl is installed
-  stat: 
+  stat:
     path: '{{ rvm1_install_path }}/usr/ssl/openssl.cnf'
   ignore_errors: True
-  when: 
+  when:
     rvm1_install_openssl is defined and
     rvm1_install_openssl == True
   register: detect_rvm_openssl_pkg
 
-- name: Add --with-openssl-dir to rvm1_install_flags 
-  set_fact: 
+- name: Add --with-openssl-dir to rvm1_install_flags
+  set_fact:
     rvm1_ruby_install_flags='--with-openssl-dir={{ rvm1_install_path }}/usr {{ rvm1_ruby_install_flags }}'
     #'
-  when: 
+  when:
     (rvm1_rubies and item.rc|default(0) != 0) and
     rvm1_install_openssl is defined and
     rvm1_install_openssl == True
   with_items: '{{ detect_rubies.results }}'
   sudo_user: '{{ rvm1_user }}'
 
-- debug: 
+- debug:
     msg:
       "rvm1_ruby_install_flags => '{{ rvm1_ruby_install_flags }}'"
 
 - name: Install rvm pkg install openssl
   command: '{{ rvm1_rvm }} pkg install openssl'
   sudo: true
-  when: 
+  when:
     detect_rvm_openssl_pkg.stat.exists == False and
     rvm1_install_openssl is defined and
     rvm1_install_openssl == True
@@ -110,7 +110,7 @@
   changed_when: '"Successfully installed bundler" in bundler_install.stdout'
   become: yes
   become_user: '{{ rvm1_user }}'
-  
+
 - name: Symlink ruby related binaries on the system path
   file:
     state: 'link'
@@ -120,7 +120,7 @@
     group: 'root'
   when: not '--user-install' in rvm1_install_flags
   with_items: '{{ rvm1_symlink_binaries }}'
-  
+
 - name: Detect if ruby version can be deleted
   command: '{{ rvm1_rvm }} {{ rvm1_delete_ruby }} do true'
   changed_when: False

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -54,7 +54,6 @@
     rvm1_install_openssl is defined and
     rvm1_install_openssl == True
   with_items: '{{ detect_rubies.results }}'
-  sudo_user: '{{ rvm1_user }}'
 
 - debug:
     msg:
@@ -62,11 +61,11 @@
 
 - name: Install rvm pkg install openssl
   command: '{{ rvm1_rvm }} pkg install openssl'
-  sudo: true
   when:
     detect_rvm_openssl_pkg.stat.exists == False and
     rvm1_install_openssl is defined and
     rvm1_install_openssl == True
+  become: true
 
 - name: Install rubies
   command: '{{ rvm1_rvm }} install {{ item.item }} {{ rvm1_ruby_install_flags }}'

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -28,12 +28,14 @@
   tags:
     - apt
 
+# Allow for distro-specific overrides
+# e.g. to allow for rvm to install openssl on Debian stretch/testing
+#      - ruby fails to build with openssl 1.0.2
 - name: Include distribution release specific variables
   include_vars: '{{ item }}'
   with_first_found:
     - "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"
     - "openssl.yml"
-  # when: release_vars.stat.exists == True
 
 # Appears we have to test a file as rvm has no way to list packages it installed
 - name: Determine if rvm pkg openssl is installed

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -8,6 +8,66 @@
   with_items: '{{ rvm1_rubies }}'
   when: rvm1_rubies
 
+# Workaround for debian testing where ansible is unable to divine the release
+- name: Determine distribution_release
+  shell: awk -F/ '{print $1}' /etc/debian_version
+  register: distribution_release
+  when: 
+    ansible_distribution == 'Debian' and
+    ansible_distribution_release == 'NA'
+  always_run: yes
+  tags:
+    - apt
+
+- name: Set ansible_distribution_release
+  set_fact: 'ansible_distribution_release="{{ distribution_release.stdout }}"'
+  when:
+    ansible_distribution == 'Debian' and
+    ansible_distribution_release == 'NA'
+  always_run: yes
+  tags:
+    - apt
+
+- name: Include distribution release specific variables
+  include_vars: '{{ item }}'
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_release }}.yml"
+    - "openssl.yml"
+  # when: release_vars.stat.exists == True
+
+# Appears we have to test a file as rvm has no way to list packages it installed
+- name: Determine if rvm pkg openssl is installed
+  stat: 
+    path: '{{ rvm1_install_path }}/usr/ssl/openssl.cnf'
+  ignore_errors: True
+  when: 
+    rvm1_install_openssl is defined and
+    rvm1_install_openssl == True
+  register: detect_rvm_openssl_pkg
+
+- name: Add --with-openssl-dir to rvm1_install_flags 
+  set_fact: 
+    rvm1_ruby_install_flags='--with-openssl-dir={{ rvm1_install_path }}/usr {{ rvm1_ruby_install_flags }}'
+    #'
+  when: 
+    (rvm1_rubies and item.rc|default(0) != 0) and
+    rvm1_install_openssl is defined and
+    rvm1_install_openssl == True
+  with_items: '{{ detect_rubies.results }}'
+  sudo_user: '{{ rvm1_user }}'
+
+- debug: 
+    msg:
+      "rvm1_ruby_install_flags => '{{ rvm1_ruby_install_flags }}'"
+
+- name: Install rvm pkg install openssl
+  command: '{{ rvm1_rvm }} pkg install openssl'
+  sudo: true
+  when: 
+    detect_rvm_openssl_pkg.stat.exists == False and
+    rvm1_install_openssl is defined and
+    rvm1_install_openssl == True
+
 - name: Install rubies
   command: '{{ rvm1_rvm }} install {{ item.item }} {{ rvm1_ruby_install_flags }}'
   when: rvm1_rubies and item.rc|default(0) != 0

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -26,10 +26,18 @@
     mode: 0755
   when: not rvm_binary.stat.exists
 
+- name: Determine if rvm gpg signing keys are installed
+  shell:
+    gpg --list-keys '{{ rvm1_gpg_keys }}'
+  always_run: yes
+  ignore_errors: True
+  register: rvm_signing_keys_exist
+
 - name: Import GPG keys
-  command: 'gpg --keyserver {{ rvm1_gpg_key_server }} --recv-keys {{ rvm1_gpg_keys }}'
+  command:
+    'gpg --keyserver {{ rvm1_gpg_key_server }} --recv-keys {{ rvm1_gpg_keys }}'
   changed_when: False
-  when: rvm1_gpg_keys != ''
+  when: (rvm1_gpg_keys != '') and (rvm_signing_keys_exist.rc != 0)
   become: yes
   become_user: '{{ rvm1_user }}'
 

--- a/vars/Debian-stretch.yml
+++ b/vars/Debian-stretch.yml
@@ -1,0 +1,9 @@
+﻿---
+
+# workaround for debian stretch where the ruby build 
+# fails with an incompatibility with libssl/openssl (1.0.2) 
+# provided by debian.
+
+# Allow for rvm to install openssl
+
+rvm1_install_openssl: True

--- a/vars/Debian-stretch.yml
+++ b/vars/Debian-stretch.yml
@@ -1,7 +1,7 @@
-﻿---
+---
 
-# workaround for debian stretch where the ruby build 
-# fails with an incompatibility with libssl/openssl (1.0.2) 
+# workaround for debian stretch where the ruby build
+# fails with an incompatibility with libssl/openssl (1.0.2)
 # provided by debian.
 
 # Allow for rvm to install openssl

--- a/vars/openssl.yml
+++ b/vars/openssl.yml
@@ -1,0 +1,5 @@
+﻿---
+
+# Prefer the version of libssl/openssl provideded by
+# the distro
+rvm1_install_openssl: False

--- a/vars/openssl.yml
+++ b/vars/openssl.yml
@@ -1,4 +1,4 @@
-﻿---
+---
 
 # Prefer the version of libssl/openssl provideded by
 # the distro


### PR DESCRIPTION
- Allow rvm to install the openssl pkg (primarily because ruby fails to build with the version of openssl/libssl that's currently in Debian stretch/testing and to get around the host of other issues relating to openssl - see https://github.com/rbenv/ruby-build/issues?utf8=%E2%9C%93&q=openssl).
- Introduce a new variable (`rvm1_install_openssl` defaults to `False` except when `ansible_distribution_release == 'stretch'`) that allows the user to control the installation of the rvm openssl pkg.
