### PR TITLE
Parameterize superuser/group names

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,5 +46,5 @@ rvm1_autolib_mode: 3
 # Name of UID 0 user
 root_user: 'root'
 
-# Name of GID 0 group -- BSD systems typically use wheel
-root_group: 'root'
+# Name of GID 0 group -- BSD systems typically use wheel instead of root
+root_group: '{{ root_user }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,9 @@ rvm1_gpg_key_server: 'hkp://keys.gnupg.net'
 
 # autolib mode, see https://rvm.io/rvm/autolibs
 rvm1_autolib_mode: 3
+
+# Name of UID 0 user
+root_user: 'root'
+
+# Name of GID 0 group -- BSD systems typically use wheel
+root_group: 'root'

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -50,17 +50,17 @@
   changed_when: '"Successfully installed bundler" in bundler_install.stdout'
   become: yes
   become_user: '{{ rvm1_user }}'
-  
+
 - name: Symlink ruby related binaries on the system path
   file:
     state: 'link'
     src: '{{ rvm1_install_path }}/wrappers/default/{{ item }}'
     dest: '{{ rvm1_symlink_to }}/{{ item }}'
-    owner: 'root'
-    group: 'root'
+    owner: '{{ root_user }}'
+    group: '{{ root_group }}'
   when: not '--user-install' in rvm1_install_flags
   with_items: '{{ rvm1_symlink_binaries }}'
-  
+
 - name: Detect if ruby version can be deleted
   command: '{{ rvm1_rvm }} {{ rvm1_delete_ruby }} do true'
   changed_when: False


### PR DESCRIPTION
Perhaps this should be changed to use the numeric IDs (0).  But, in BSD land group 0 is typically wheel (not root).