### PR TITLE
Accept 'rvm1_rubies' as a single string version

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,7 +2,7 @@
 
 rvm1_temp_download_path: '/tmp'
 
-rvm1_default_ruby_version: '{{ rvm1_rubies | last if rvm1_rubies and rvm1_rubies is iterable else "" }}'
+rvm1_default_ruby_version: '{{ rvm1_rubies | last if rvm1_rubies and rvm1_rubies is iterable else rvm1_rubies }}'
 
 rvm1_rvm: '{{ rvm1_install_path }}/bin/rvm'
 


### PR DESCRIPTION
If 'rvm1_rubies' is a string with a single Ruby version (a common mistake), the role currently installs it correctly but subsequently fails to symlink the default wrappers; with this change it will instead correctly use the given version.