### PR TITLE
Better way to import gpg keys for ubuntu server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,15 +34,6 @@ rvm1_rvm_version: 'stable'
 # Check and update rvm, disabling this will force rvm to never update
 rvm1_rvm_check_for_updates: True
 
-# GPG key verification, use an empty string if you want to skip this
-# Note: Unless you know what you're doing, just keep it as is
-#           Identity proof: https://keybase.io/mpapis
-#           PGP message: https://rvm.io/mpapis.asc
-rvm1_gpg_keys: 'D39DC0E3'
-
-# The GPG key server
-rvm1_gpg_key_server: 'hkp://keys.gnupg.net'
-
 # autolib mode, see https://rvm.io/rvm/autolibs
 rvm1_autolib_mode: 3
 

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -25,11 +25,10 @@
     path: '{{ rvm1_temp_download_path }}/rvm-installer.sh'
     mode: 0755
   when: not rvm_binary.stat.exists
-
+  
 - name: Import GPG keys
-  command: 'gpg --keyserver {{ rvm1_gpg_key_server }} --recv-keys {{ rvm1_gpg_keys }}'
+  shell: curl -sSL https://rvm.io/mpapis.asc | gpg --import
   changed_when: False
-  when: rvm1_gpg_keys != ''
   register: result
   until: result.rc == 0
   retries: 5


### PR DESCRIPTION
In my server the task to import gpg keys didn't work. Therefore, I modified the task to solve the problem. This pull request not only fixes gpg key problem, but it is also dynamic, adjusting to changes in the keys.