### PR TITLE
Import GPG keys the other way

### DIFF
--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -30,10 +30,15 @@
   command: 'gpg --keyserver {{ rvm1_gpg_key_server }} --recv-keys {{ rvm1_gpg_keys }}'
   changed_when: False
   when: rvm1_gpg_keys != ''
-  register: result
-  until: result.rc == 0
+  register: gpg_result
+  until: gpg_result.rc == 0
   retries: 5
   delay: 5
+  ignore_errors: True
+
+- name: Import GPG keys the other way
+  shell: curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+  when: rvm1_gpg_keys != '' and gpg_result.rc != 0
 
 - name: Install rvm
   command: >


### PR DESCRIPTION
Step "Import GPG keys" always fails on our hardened ubuntu 14.04. Could be either the version of our ubuntu we are using, or the company firewall. Adding the alternative method to import GPG key in case first method fails.