### PR TITLE
Fix ansible-galaxy installation parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ using a version manager while still benefiting from what rvm has to offer.
 
 ## Installation
 
-`$ ansible-galaxy install rvm_io.rvm1-ruby`
+`$ ansible-galaxy install rvm_io.ruby`
 
 ## Role variables
 


### PR DESCRIPTION
    nfedyashev@MacPro : ~
    [0] % ansible-galaxy install rvm_io.rvm1-ruby
    - downloading role 'rvm1-ruby', owned by rvm_io
     [WARNING]: - rvm_io.rvm1-ruby was NOT installed successfully: - sorry, rvm_io.rvm1-ruby was not found on https://galaxy.ansible.com.
    
    ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
    
    nfedyashev@MacPro : ~
    [1] % ansible-galaxy install rvm_io.ruby
    - downloading role 'ruby', owned by rvm_io
    - downloading role from https://github.com/rvm/rvm1-ansible/archive/v1.3.9.tar.gz
    - extracting rvm_io.ruby to /usr/local/etc/ansible/roles/rvm_io.ruby
    - rvm_io.ruby was installed successfully
