### PR TITLE
Use 'mode' parameter of 'get_url' module

### DIFF
--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -18,13 +18,8 @@
   get_url:
     url: '{{ rvm1_rvm_latest_installer }}'
     dest: '{{ rvm1_temp_download_path }}/rvm-installer.sh'
-  when: not rvm_installer.stat.exists
-
-- name: Configure rvm installer
-  file:
-    path: '{{ rvm1_temp_download_path }}/rvm-installer.sh'
     mode: 0755
-  when: not rvm_binary.stat.exists
+  when: not rvm_installer.stat.exists
 
 - name: Import GPG keys
   command: 'gpg --keyserver {{ rvm1_gpg_key_server }} --recv-keys {{ rvm1_gpg_keys }}'


### PR DESCRIPTION
The ['get_url' module](http://docs.ansible.com/ansible/get_url_module.html) has a `mode` parameter which can be used instead of the 'Configure rvm installer' task.

This PR also fixes an issue in the when statement where `rvm_binary` is checked instead of `rvm_installer`