### PR TITLE
Use check_mode instead of always run

### DIFF
--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -29,7 +29,7 @@
   with_items: '{{ rvm1_rubies }}'
   changed_when: False
   register: ruby_patch
-  always_run: yes # Run even when in --check mode (http://docs.ansible.com/ansible/playbooks_checkmode.html)
+  check_mode: no # Run in normal mode even when in --check mode (http://docs.ansible.com/ansible/playbooks_checkmode.html)
 
 - name: Install bundler if not installed
   shell: >


### PR DESCRIPTION
Fixes the following deprecation warning:

> TASK [rvm_io.ruby : Detect installed ruby patch number] ************************
> [DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
> This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

Using Ansible 2.2.0.0