### PR TITLE
Add missing commas to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ If you need to pass a list of ruby versions, pass it in an array like so.
   roles:
     - { role: rvm_io.ruby,
         tags: ruby,
-        become: yes
+        become: yes,
 
         rvm1_rubies: ['ruby-2.2.5','ruby-2.3.1'],
-        rvm1_install_flags: '--auto-dotfiles'     # Remove --user-install from defaults
-        rvm1_install_path: /usr/local/rvm         # Set to system location
-        rvm1_user: root                           # Need root account to access system location
+        rvm1_install_flags: '--auto-dotfiles',     # Remove --user-install from defaults
+        rvm1_install_path: /usr/local/rvm,         # Set to system location
+        rvm1_user: root                            # Need root account to access system location
       }
 ```
 _rvm_rubies must be specified via `ruby-x.x.x` so that if you want_


### PR DESCRIPTION
One of the examples was missing some commas and resulted in invalid YAML