### PR TITLE
CentOS/RHEL: conditionally install which

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 ## MASTER
 
+### v2.0.2
+
+* Install `which` via the package manager for RHEL/CentOS distributions
+
 ### v2.0.1
 * Fix issue `src file does not exist` cause by testrb
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Install system dependencies
+  include: 'system-dependencies.yml'
+  become: yes
+  ignore_errors: true
+
 - name: Install RVM
   include: 'rvm.yml'
   become: yes

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -36,15 +36,6 @@
   shell: curl -sSL https://rvm.io/mpapis.asc | gpg --import -
   when: not ansible_check_mode and rvm1_gpg_keys != '' and gpg_result.rc != 0
 
-- name: Install which (CentOS, RHEL)
-  become_user: root
-  yum:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - which
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-
 - name: Install rvm
   command: >
     {{ rvm1_temp_download_path }}/rvm-installer.sh {{ rvm1_rvm_version }}

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -37,8 +37,6 @@
   when: not ansible_check_mode and rvm1_gpg_keys != '' and gpg_result.rc != 0
 
 - name: Install which (CentOS, RHEL)
-  become: yes
-  become_user: root
   yum:
     name: "{{ item }}"
     state: present

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -36,6 +36,15 @@
   shell: curl -sSL https://rvm.io/mpapis.asc | gpg --import -
   when: not ansible_check_mode and rvm1_gpg_keys != '' and gpg_result.rc != 0
 
+- name: Install which (CentOS, RHEL)
+  become: yes
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - which
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+
 - name: Install rvm
   command: >
     {{ rvm1_temp_download_path }}/rvm-installer.sh {{ rvm1_rvm_version }}

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -37,6 +37,7 @@
   when: not ansible_check_mode and rvm1_gpg_keys != '' and gpg_result.rc != 0
 
 - name: Install which (CentOS, RHEL)
+  become_user: root
   yum:
     name: "{{ item }}"
     state: present

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -38,6 +38,7 @@
 
 - name: Install which (CentOS, RHEL)
   become: yes
+  become_user: root
   yum:
     name: "{{ item }}"
     state: present

--- a/tasks/system-dependencies.yml
+++ b/tasks/system-dependencies.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Install which (CentOS, RHEL)
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - which
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'

--- a/tests/dockerfiles/centos7/Dockerfile
+++ b/tests/dockerfiles/centos7/Dockerfile
@@ -3,7 +3,6 @@ FROM centos:7
 RUN yum update -y && \
     yum install -y \
 			sudo \
-			which \
 		&& yum clean all
 
 RUN useradd -ms /bin/bash user \

--- a/tests/user.yml
+++ b/tests/user.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
-  gather_facts: false
+  gather_facts: true
   remote_user: user
   vars:
     rvm1_user: user
@@ -14,7 +14,7 @@
 
 # Asserts tasks
 - hosts: all
-  gather_facts: false
+  gather_facts: true
   remote_user: user
   tasks:
     - name: Assert tasks


### PR DESCRIPTION
The default CentOS/RHEL installation does not include `which` which is a prerequisite for the role installation. The CentOS Docker image used for testing in Travis works around this limitation by installing `which` on top of the base `centos:centos7` image.

Consumers of the role either in a playbook or as a dependency of a downstream role need to use `pre_task`, `include_role` or have another role installing the prerequisites - see https://github.com/openmicroscopy/ansible-role-jekyll-build/pull/10.

This PR proposes to tackle this limitation by conditionally installing the `which` package when appropriate using the `ansible_distribution`. The main impact of this change is its requirement for setting `gather_facts` to its default `true` value in the consuming playbooks.

Similar issues have been reported for other distributions and could be addressed the same way - see https://github.com/rvm/rvm1-ansible/issues/32
