### PR TITLE
Replace include with import_playbook to address deprecation in 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 install:
-  - sudo pip install ansible==2.2.2 > /dev/null 2>&1
+  - sudo pip install ansible==2.4.6.0 > /dev/null 2>&1
 
 script:
   - cd tests

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: The official rvm role to install and manage your ruby versions.
   company: ''
   license: license (MIT)
-  min_ansible_version: 2.2
+  min_ansible_version: 2.4
 
   platforms:
     - name: EL

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Install RVM
-  include: 'rvm.yml'
+  import_tasks: 'rvm.yml'
   become: yes
   become_user: '{{ rvm1_user }}'
 
 - name: Install Ruby and Gems
-  include: 'rubies.yml'
+  import_tasks: 'rubies.yml'
   become: yes
   become_user: '{{ rvm1_user }}'

--- a/tests/root.yml
+++ b/tests/root.yml
@@ -16,4 +16,4 @@
   gather_facts: false
   tasks:
     - name: Assert tasks
-      include: assertions.yml
+      import_tasks: assertions.yml

--- a/tests/user.yml
+++ b/tests/user.yml
@@ -18,4 +18,4 @@
   remote_user: user
   tasks:
     - name: Assert tasks
-      include: assertions.yml
+      import_tasks: assertions.yml


### PR DESCRIPTION
Ansible 2.4 deprecated the use of 'include' for playbook includes with
plans to remove it completely in version 2.8. Replace the places where
it was used with the new 'import_playbook' and update the minimum
ansible version.

See https://github.com/rvm/rvm1-ansible/issues/169