### PR TITLE
Show docker-compose output in Travis to address build timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
 script:
   - cd tests
-  - docker-compose up -d > /dev/null 2>&1
+  - docker-compose up -d
   - ansible-playbook user.yml -l centos
   - ansible-playbook user.yml -l debian
   - ansible-playbook user.yml -l ubuntu


### PR DESCRIPTION
It takes long enough to build the 6 different distro containers used for
tests that Travis is killing the build during docker-compose up. In the
Travis output, there's a message "No output has been received in the
last 10m0s", which suggests it's killing the job early in part because
we're sending all docker-compose output to /dev/null. Try showing all of
that output in the hopes of improving build reliability.