### PR TITLE
Check rvm1_delete_ruby is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * ...
 
+### Unreleased
+* Fix 'ruby' is undefined error when using `rvm1_delete_ruby`. Issue: #156
+
 ### 2.1.2
 2018-12-28 &middot; [Changes](https://github.com/rvm/rvm1-ansible/compare/v2.1.1...v2.1.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 * Fixes bare variables in conditionals (deprecation warnings with Ansible 2.8+) (#204)
 * Fix boolean values when checking array (#207)
-
-### Unreleased
-* Fix 'ruby' is undefined error when using `rvm1_delete_ruby`. Issue: #156
+* Fix 'ruby' is undefined error when using `rvm1_delete_ruby` (#156)
 
 ### 2.1.2
 2018-12-28 &middot; [Changes](https://github.com/rvm/rvm1-ansible/compare/v2.1.1...v2.1.2)

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -67,9 +67,11 @@
   changed_when: False
   failed_when: False
   register: detect_delete_ruby
-  when: rvm1_delete_ruby
+  when: rvm1_delete_ruby is defined
 
 - name: Delete ruby version
   command: '{{ rvm1_rvm }} remove {{ rvm1_delete_ruby }}'
   changed_when: False
-  when: rvm1_delete_ruby and detect_delete_ruby.rc == 0
+  when:
+    - rvm1_delete_ruby is defined
+    - detect_delete_ruby.rc == 0


### PR DESCRIPTION
Fixes `'ruby' is undefined` error when using `rvm1_delete_ruby`

Fixes #156