### PR TITLE
Specify bundler install version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ rvm1_rubies:
 # Install the bundler gem
 rvm1_bundler_install: True
 
+# Specify a version of bundler
+rvm1_bundler_version: 2.0.1
+
 # Delete a specific version of ruby (ie. ruby-2.1.0)
 rvm1_delete_ruby:
 

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -34,7 +34,7 @@
 - name: Install bundler if not installed
   shell: >
     ls {{ rvm1_install_path }}/wrappers/{{ item.stdout }}
-    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item.stdout }}/gem install bundler ; fi
+    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item.stdout }}/gem install bundler:{{ rvm1_bundler_version }} ; fi
   args:
     creates: '{{ rvm1_install_path }}/wrappers/{{ item.stdout }}/bundler'
   with_items: '{{ ruby_patch.results }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -16,6 +16,8 @@ rvm1_symlink_binaries:
   - 'ri'
   - 'ruby'
 
+rvm1_bundler_version: 2.0.1
+
 rvm1_symlink_bundler_binaries:
   - 'bundle'
   - 'bundler'


### PR DESCRIPTION
Bundler 2 is not backwards compatible with Bundler 1, so we need to specify a version. This keeps the default at the current version (2.0.1), but provides a variable for the user to configure. 