### PR TITLE
Fixes bare variables in conditionals (deprecation warnings with Ansible 2.8+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ### NEXT
 
-* Fixes bare variables in conditionals (deprecation warnings with Ansible 2.8+) 
-* …
+* Fixes bare variables in conditionals (deprecation warnings with Ansible 2.8+) (#204)
 
 ### 2.1.2
 2018-12-28 &middot; [Changes](https://github.com/rvm/rvm1-ansible/compare/v2.1.1...v2.1.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### NEXT
 
-* ...
+* Fixes bare variables in conditionals (deprecation warnings with Ansible 2.8+) 
+* …
 
 ### 2.1.2
 2018-12-28 &middot; [Changes](https://github.com/rvm/rvm1-ansible/compare/v2.1.1...v2.1.2)

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -6,11 +6,11 @@
   failed_when: False
   register: detect_rubies
   with_items: '{{ rvm1_rubies }}'
-  when: rvm1_rubies
+  when: rvm1_rubies | bool
 
 - name: Install rubies
   command: '{{ rvm1_rvm }} install {{ item.item }} {{ rvm1_ruby_install_flags }}'
-  when: rvm1_rubies and item.rc|default(0) != 0
+  when: rvm1_rubies | bool and item.rc|default(0) != 0
   with_items: '{{ detect_rubies.results }}'
 
 - name: Detect default ruby version
@@ -67,9 +67,9 @@
   changed_when: False
   failed_when: False
   register: detect_delete_ruby
-  when: rvm1_delete_ruby
+  when: rvm1_delete_ruby | bool
 
 - name: Delete ruby version
   command: '{{ rvm1_rvm }} remove {{ rvm1_delete_ruby }}'
   changed_when: False
-  when: rvm1_delete_ruby and detect_delete_ruby.rc == 0
+  when: rvm1_delete_ruby | bool and detect_delete_ruby.rc == 0


### PR DESCRIPTION
This PR is about fixing some warning messages showing up in the console when running the role with ansible ≥ 2.8 