### PR TITLE
Fix boolean values when checking array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### NEXT
 
 * Fixes bare variables in conditionals (deprecation warnings with Ansible 2.8+) (#204)
-* Fix boolean values when checking array (#207
+* Fix boolean values when checking array (#207)
 
 ### 2.1.2
 2018-12-28 &middot; [Changes](https://github.com/rvm/rvm1-ansible/compare/v2.1.1...v2.1.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ### NEXT
 
 * Fixes bare variables in conditionals (deprecation warnings with Ansible 2.8+) (#204)
+* Fix boolean values when checking array (#207
 
 ### 2.1.2
 2018-12-28 &middot; [Changes](https://github.com/rvm/rvm1-ansible/compare/v2.1.1...v2.1.2)
-
+)
 * Fallback to alternative GPG key servers (#192)
 * Remove keys.gnupg.net in favour of pool.sks-keyservers.net (#192)
 

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -6,11 +6,11 @@
   failed_when: False
   register: detect_rubies
   with_items: '{{ rvm1_rubies }}'
-  when: rvm1_rubies | bool
+  when: rvm1_rubies is defined and rvm1_rubies | length > 0
 
 - name: Install rubies
   command: '{{ rvm1_rvm }} install {{ item.item }} {{ rvm1_ruby_install_flags }}'
-  when: rvm1_rubies | bool and item.rc|default(0) != 0
+  when: rvm1_rubies is defined and rvm1_rubies | length > 0 and item.rc|default(0) != 0
   with_items: '{{ detect_rubies.results }}'
 
 - name: Detect default ruby version


### PR DESCRIPTION
I think checking condition like this: ```rvm1_rubies | bool``` doesn't work for array. It is always false.
This causes an error:
```
"stderr": "/bin/sh: /home/user/.rvm/wrappers//gem: not found"
```
Looks like checking using `| length` works for arrays but it is also works for strings.