### PR TITLE
Fix incorrect bool casts

### DIFF
--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -6,11 +6,11 @@
   failed_when: False
   register: detect_rubies
   with_items: '{{ rvm1_rubies }}'
-  when: rvm1_rubies | bool
+  when: rvm1_rubies | length > 0
 
 - name: Install rubies
   command: '{{ rvm1_rvm }} install {{ item.item }} {{ rvm1_ruby_install_flags }}'
-  when: rvm1_rubies | bool and item.rc|default(0) != 0
+  when: rvm1_rubies | length > 0 and item.rc|default(0) != 0
   with_items: '{{ detect_rubies.results }}'
 
 - name: Detect default ruby version
@@ -67,9 +67,9 @@
   changed_when: False
   failed_when: False
   register: detect_delete_ruby
-  when: rvm1_delete_ruby | bool
+  when: rvm1_delete_ruby is defined
 
 - name: Delete ruby version
   command: '{{ rvm1_rvm }} remove {{ rvm1_delete_ruby }}'
   changed_when: False
-  when: rvm1_delete_ruby | bool and detect_delete_ruby.rc == 0
+  when: detect_delete_ruby.rc is defined and detect_delete_ruby.rc == 0


### PR DESCRIPTION
The deprecation fix (deb1d3e) uses `<variable> | bool` to check whether a list was non-empty or a variable was defined. However, the `bool` filter just tries to cast its input to a boolean and string values become `false`.

This PR fixes the intended behaviour by checking if variables are defined and lists are non-empty.