### PR TITLE
Conditionally symlink Ruby related executables on the system path

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ rvm1_gpg_key_server: 'hkp://pool.sks-keyservers.net'
 
 # autolib mode, see https://rvm.io/rvm/autolibs
 rvm1_autolib_mode: 3
+
+# Symlink Ruby related executables on the system path
+# for multi-user installation
+rvm1_symlink_for_multi_user_install: True
+
 ```
 
 ## Example playbooks

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,10 @@ rvm1_gpg_key_servers:
 # autolib mode, see https://rvm.io/rvm/autolibs
 rvm1_autolib_mode: 3
 
+# Symlink Ruby related executables on the system path
+# for multi-user installation
+rvm1_symlink_for_multi_user_install: True
+
 # Name of UID 0 user
 root_user: 'root'
 

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -45,7 +45,7 @@
     dest: '{{ rvm1_symlink_to }}/{{ item }}'
     owner: '{{ root_user }}'
     group: '{{ root_group }}'
-  when: not '--user-install' in rvm1_install_flags
+  when: not '--user-install' in rvm1_install_flags and rvm1_symlink_for_multi_user_install
   with_items: '{{ rvm1_symlink_binaries }}'
 
 - name: Symlink bundler binaries on the system path


### PR DESCRIPTION
I've added variable `rvm1_symlink_for_multi_user_install` with default value `True` which indicates to symlink Ruby related executables on the system path for multi-user installations. This doesn't break backward compatibility because of it's default value.

```
TASK [rvm.ruby : Symlink ruby related binaries on the system path] *************
changed: [articles.crypto-libertarian.com] => (item=erb)
changed: [articles.crypto-libertarian.com] => (item=executable-hooks-uninstaller)
changed: [articles.crypto-libertarian.com] => (item=gem)
changed: [articles.crypto-libertarian.com] => (item=irb)
changed: [articles.crypto-libertarian.com] => (item=rake)
changed: [articles.crypto-libertarian.com] => (item=rdoc)
changed: [articles.crypto-libertarian.com] => (item=ri)
changed: [articles.crypto-libertarian.com] => (item=ruby)
```

P.S. Found similar PR: #94. However, it haven't been merged since 2016 for some reason.
