### PR TITLE
update tasks/rubies.yml - fix bool misuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fixes bare variables in conditionals (deprecation warnings with Ansible 2.8+) (#204)
 * Fix boolean values when checking array (#207)
+* Fix conditional logic for detecting and removing versions of Ruby (#212)
+* Report when Ruby is removed and don't ignore when version listing fails (#212)
 
 ### 2.1.2
 2018-12-28 &middot; [Changes](https://github.com/rvm/rvm1-ansible/compare/v2.1.1...v2.1.2)

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -62,14 +62,16 @@
   when: not '--user-install' in rvm1_install_flags and rvm1_bundler_install
   with_items: '{{ rvm1_symlink_bundler_binaries }}'
 
-- name: Detect if ruby version can be deleted
-  command: '{{ rvm1_rvm }} {{ rvm1_delete_ruby }} do true'
+- name: List installed versions of Ruby (for deletion)
+  command: '{{ rvm1_rvm }} list strings'
   changed_when: False
-  failed_when: False
-  register: detect_delete_ruby
+  register: rvm1_list_installed_rubies
   when: rvm1_delete_ruby is defined and rvm1_delete_ruby != ''
 
-- name: Delete ruby version
+- name: Delete ruby if relevant
   command: '{{ rvm1_rvm }} remove {{ rvm1_delete_ruby }}'
-  changed_when: False
-  when: rvm1_delete_ruby is defined and rvm1_delete_ruby != '' and detect_delete_ruby.rc == 0
+  register: rvm_delete_command_result
+  changed_when: "'#removing' in rvm_delete_command_result.stdout"
+  when:
+    - rvm1_delete_ruby is defined and rvm1_delete_ruby != ''
+    - rvm1_delete_ruby in rvm1_list_installed_rubies.stdout.splitlines()

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -67,9 +67,9 @@
   changed_when: False
   failed_when: False
   register: detect_delete_ruby
-  when: rvm1_delete_ruby != ''
+  when: rvm1_delete_ruby is defined and rvm1_delete_ruby != ''
 
 - name: Delete ruby version
   command: '{{ rvm1_rvm }} remove {{ rvm1_delete_ruby }}'
   changed_when: False
-  when: rvm1_delete_ruby != '' and detect_delete_ruby.rc == 0
+  when: rvm1_delete_ruby is defined and rvm1_delete_ruby != '' and detect_delete_ruby.rc == 0

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -6,11 +6,11 @@
   failed_when: False
   register: detect_rubies
   with_items: '{{ rvm1_rubies }}'
-  when: rvm1_rubies | bool
+  when: rvm1_rubies is defined
 
 - name: Install rubies
   command: '{{ rvm1_rvm }} install {{ item.item }} {{ rvm1_ruby_install_flags }}'
-  when: rvm1_rubies | bool and item.rc|default(0) != 0
+  when: rvm1_rubies is defined and item.rc|default(0) != 0
   with_items: '{{ detect_rubies.results }}'
 
 - name: Detect default ruby version
@@ -67,9 +67,9 @@
   changed_when: False
   failed_when: False
   register: detect_delete_ruby
-  when: rvm1_delete_ruby | bool
+  when: rvm1_delete_ruby != ''
 
 - name: Delete ruby version
   command: '{{ rvm1_rvm }} remove {{ rvm1_delete_ruby }}'
   changed_when: False
-  when: rvm1_delete_ruby | bool and detect_delete_ruby.rc == 0
+  when: rvm1_delete_ruby != '' and detect_delete_ruby.rc == 0

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -38,7 +38,7 @@
   args:
     creates: '{{ rvm1_install_path }}/wrappers/{{ item.stdout }}/bundler'
   with_items: '{{ ruby_patch.results }}'
-  when: rvm1_bundler_install
+  when: rvm1_bundler_install and rvm1_default_ruby_version is version('ruby-2.3.0', 'ge')
   register: bundler_install
   changed_when: '"Successfully installed bundler" in bundler_install.stdout'
 

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -38,7 +38,7 @@
   args:
     creates: '{{ rvm1_install_path }}/wrappers/{{ item.stdout }}/bundler'
   with_items: '{{ ruby_patch.results }}'
-  when: rvm1_bundler_install and rvm1_default_ruby_version is version('ruby-2.3.0', 'ge')
+  when: rvm1_bundler_install
   register: bundler_install
   changed_when: '"Successfully installed bundler" in bundler_install.stdout'
 


### PR DESCRIPTION
This fixes issues introduced by https://github.com/rvm/rvm1-ansible/commit/deb1d3e6212d9ec6605510554bf268d18688513e as described by #209. The linked commit resolved warnings about bare variables in conditionals, but ended up breaking the conditional logic by misusing the `bool` filter. The `bool` filter returns `true` for vars set to ‘yes’, ‘on’, ‘1’, and ‘true’, and returns `false` otherwise, see https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html.
