### PR TITLE
Add rvm1_delete_unmanaged_rubies option (and deprecate rvm1_delete_ruby)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - cd tests
   - docker-compose config --services | grep $PLATFORM | xargs docker-compose up -d
   # 'Simulate' a previous installation
-  - ansible-playbook $PLAYBOOK -l $PLATFORM -t setup -e '{"rvm1_rubies" : ["ruby-2.5.7"]}'
+  - ansible-playbook $PLAYBOOK -l $PLATFORM -t setup -e \{\"rvm1_rubies\":\[\"ruby-2.5.7\"\]\}
   # Execute the RVM and Ruby udpates and validate the final state
   - ansible-playbook $PLAYBOOK -l $PLATFORM
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,9 @@ install:
 script:
   - cd tests
   - docker-compose config --services | grep $PLATFORM | xargs docker-compose up -d
+  # 'Simulate' a previous installation
+  - ansible-playbook $PLAYBOOK -l $PLATFORM -t setup -e '{"rvm1_rubies" : ["ruby-2.5.7"]}'
+  # Execute the RVM and Ruby udpates and validate the final state
   - ansible-playbook $PLAYBOOK -l $PLATFORM
 
 before_cache:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ rvm1_rubies:
 rvm1_bundler_install: True
 
 # Delete a specific version of ruby (ie. ruby-2.1.0)
+# DEPRECATED: Use 'rvm1_delete_unmanaged_rubies' instead,
+# as this option will be removed in a future release
 rvm1_delete_ruby:
+
+# Delete installed ruby versions that are not listed in 'rvm1_rubies'
+rvm1_delete_unmanaged_rubies: False
 
 # Install path for rvm (defaults to single user)
 # NOTE: If you are doing a ROOT BASED INSTALL then make sure you
@@ -157,9 +162,10 @@ A common work flow for upgrading your ruby version would be:
 2. Run your application role so that bundle install re-installs your gems
 3. Delete the previous version of ruby
 
-### Leverage ansible's `--extra-vars`
+### Leverage ansible-playbook `--extra-vars` argument
 
-Just add `--extra-vars 'rvm1_delete_ruby=ruby-2.1.0'` to the end of your play book command and that version will be removed.
+Just add `--extra-vars 'rvm1_delete_unmanaged_rubies=yes'` to the end of your ansible-playbook command
+to ensure that only the ruby versions managed by this role will be present on the target system.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ A common work flow for upgrading your ruby version would be:
 
 ### Leverage ansible-playbook `--extra-vars` argument
 
-Just add `--extra-vars 'rvm1_delete_unmanaged_rubies=yes'` to the end of your ansible-playbook command
+Just add `--extra-vars '{ "rvm1_delete_unmanaged_rubies" : true }'` to the end of your ansible-playbook command
 to ensure that only the ruby versions managed by this role will be present on the target system.
 
 ## Requirements

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ rvm1_bundler_install: True
 # Delete a specific version of ruby (ie. ruby-2.1.0)
 rvm1_delete_ruby:
 
+# Delete installed ruby versions that are not listed in 'rvm1_rubies'
+rvm1_delete_unmanaged_rubies: False
+
 # Install path for rvm (defaults to user based install)
 rvm1_install_path: '~/.rvm'
 

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -66,14 +66,14 @@
   command: '{{ rvm1_rvm }} list strings'
   changed_when: False
   register: rvm1_list_installed_rubies
-  when: rvm1_delete_unmanaged_rubies|bool or (rvm1_delete_ruby is defined and rvm1_delete_ruby != '')
+  when: rvm1_delete_unmanaged_rubies or (rvm1_delete_ruby is defined and rvm1_delete_ruby != '')
+  check_mode: no # Run in normal mode when in --check mode (http://docs.ansible.com/ansible/playbooks_checkmode.html)
 
 - name: Delete unmanaged ruby versions
   command: '{{ rvm1_rvm }} remove {{ item }}'
   register: rvm_delete_rubies_command_result
-  changed_when: "'#removing' in rvm_delete_rubies_command_result.stdout"
-  when: rvm1_delete_unmanaged_rubies|bool
-  with_items: '{{ rvm1_list_installed_rubies.stdout.splitlines() | difference(rvm1_rubies|default([])) }}'
+  when: rvm1_delete_unmanaged_rubies
+  with_items: '{{ rvm1_list_installed_rubies.stdout_lines | difference(rvm1_rubies|default([])) }}'
 
 - name: '[DEPRECATED] Delete {{ rvm1_delete_ruby }}'
   command: '{{ rvm1_rvm }} remove {{ rvm1_delete_ruby }}'
@@ -82,4 +82,4 @@
   when:
     - not rvm1_delete_unmanaged_rubies|bool
     - rvm1_delete_ruby is defined and rvm1_delete_ruby != ''
-    - rvm1_delete_ruby in rvm1_list_installed_rubies.stdout.splitlines()
+    - rvm1_delete_ruby in rvm1_list_installed_rubies.stdout_lines

--- a/tasks/rubies.yml
+++ b/tasks/rubies.yml
@@ -62,16 +62,24 @@
   when: not '--user-install' in rvm1_install_flags and rvm1_bundler_install
   with_items: '{{ rvm1_symlink_bundler_binaries }}'
 
-- name: List installed versions of Ruby (for deletion)
+- name: List installed ruby versions (for deletion)
   command: '{{ rvm1_rvm }} list strings'
   changed_when: False
   register: rvm1_list_installed_rubies
-  when: rvm1_delete_ruby is defined and rvm1_delete_ruby != ''
+  when: rvm1_delete_unmanaged_rubies|bool or (rvm1_delete_ruby is defined and rvm1_delete_ruby != '')
 
-- name: Delete ruby if relevant
+- name: Delete unmanaged ruby versions
+  command: '{{ rvm1_rvm }} remove {{ item }}'
+  register: rvm_delete_rubies_command_result
+  changed_when: "'#removing' in rvm_delete_rubies_command_result.stdout"
+  when: rvm1_delete_unmanaged_rubies|bool
+  with_items: '{{ rvm1_list_installed_rubies.stdout.splitlines() | difference(rvm1_rubies|default([])) }}'
+
+- name: '[DEPRECATED] Delete {{ rvm1_delete_ruby }}'
   command: '{{ rvm1_rvm }} remove {{ rvm1_delete_ruby }}'
   register: rvm_delete_command_result
   changed_when: "'#removing' in rvm_delete_command_result.stdout"
   when:
+    - not rvm1_delete_unmanaged_rubies|bool
     - rvm1_delete_ruby is defined and rvm1_delete_ruby != ''
     - rvm1_delete_ruby in rvm1_list_installed_rubies.stdout.splitlines()

--- a/tests/root.yml
+++ b/tests/root.yml
@@ -9,6 +9,7 @@
     rvm1_rubies:
       - 'ruby-{{ rvm_tests_mri_version_other }}'
       - 'ruby-{{ rvm_tests_mri_version_default }}'
+    rvm1_delete_unmanaged_rubies: yes
   roles:
     - rvm1-ansible
   tags: setup

--- a/tests/user.yml
+++ b/tests/user.yml
@@ -9,6 +9,7 @@
     rvm1_rubies:
       - 'ruby-{{ rvm_tests_mri_version_other }}'
       - 'ruby-{{ rvm_tests_mri_version_default }}'
+    rvm1_delete_unmanaged_rubies: yes
   roles:
     - role: rvm1-ansible
       become: yes


### PR DESCRIPTION
This new feature came to my mind after [following discussion](https://github.com/rvm/rvm1-ansible/pull/221#issuecomment-668570038).