### PR TITLE
Fix RHEL 7 & 8 based distros to work around /tmp execution issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bug fixes
 
+* Fix RHEL 7 & 8 based distros to work around /tmp execution issues (#155)
 * Fix bare variables in conditionals (deprecation warnings with Ansible 2.8+) (#204)
 * Fix boolean values when checking array (#207)
 * Fix regression forbidding installation of rubies (#209, fixed via #207)

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -44,7 +44,7 @@
 
 - name: Install rvm
   shell: >
-    /bin/bash {{ rvm1_temp_download_path }}/rvm-installer.sh {{ rvm1_rvm_version }}
+    /usr/bin/env bash {{ rvm1_temp_download_path }}/rvm-installer.sh {{ rvm1_rvm_version }}
     --path {{ rvm1_install_path }} {{ rvm1_install_flags }}
   when: not rvm_binary.stat.exists
 

--- a/tasks/rvm.yml
+++ b/tasks/rvm.yml
@@ -44,7 +44,7 @@
 
 - name: Install rvm
   shell: >
-    {{ rvm1_temp_download_path }}/rvm-installer.sh {{ rvm1_rvm_version }}
+    /bin/bash {{ rvm1_temp_download_path }}/rvm-installer.sh {{ rvm1_rvm_version }}
     --path {{ rvm1_install_path }} {{ rvm1_install_flags }}
   when: not rvm_binary.stat.exists
 


### PR DESCRIPTION
Implements the suggested fix from #155 in order to enable rvm to install properly on CentOS 8 (and hopefully 7 and a few other distro variations as well).

Fixes #155 