### PR TITLE
Update key server URLs and decommission of sks-keyservers.net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix conditional logic for detecting and removing versions of Ruby (#212)
 * Report when Ruby is removed and don't ignore when version listing fails (#212)
 * Refactor rubies install and remove tasks, allow rvm to handle idempotency around this (#219)
+* Update key server URLs and decommission of sks-keyservers.net (#232)
 
 #### Changes
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ rvm1_rvm_check_for_updates: True
 rvm1_gpg_keys: '409B6B1796C275462A1703113804BB82D39DC0E3'
 
 # The GPG key server
-rvm1_gpg_key_server: 'hkp://pool.sks-keyservers.net'
+rvm1_gpg_key_server: 'hkp://keys.openpgp.org'
 
 # autolib mode, see https://rvm.io/rvm/autolibs
 rvm1_autolib_mode: 3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,7 @@ rvm1_gpg_key_servers:
   - '{{ rvm1_gpg_key_server }}'
   - hkp://pgp.mit.edu
   - hkp://keyserver.pgp.com
+  - hkp://keyserver.ubuntu.com
 
 # autolib mode, see https://rvm.io/rvm/autolibs
 rvm1_autolib_mode: 3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,12 +41,11 @@ rvm1_rvm_check_for_updates: True
 rvm1_gpg_keys: '409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB'
 
 # The GPG key server
-rvm1_gpg_key_server: 'hkp://pool.sks-keyservers.net'
+rvm1_gpg_key_server: 'hkp://keys.openpgp.org'
 
 # The GPG alternative key servers
 rvm1_gpg_key_servers:
   - '{{ rvm1_gpg_key_server }}'
-  - hkp://ipv4.pool.sks-keyservers.net
   - hkp://pgp.mit.edu
   - hkp://keyserver.pgp.com
 


### PR DESCRIPTION
Keyservers changed to reflect `sks-keyservers.net` no longer existing. The keyservers were modified to those of `rvm.io`, as can be seen here https://github.com/rvm/rvm-site/pull/345/files (Note: these changes have been committed, but the CI appears to be down so the changes are not on the website).


#228